### PR TITLE
Remove DnsClient requirement for compatibility

### DIFF
--- a/PowerUpSQL.ps1
+++ b/PowerUpSQL.ps1
@@ -1,4 +1,4 @@
-#requires -Modules DnsClient, Microsoft.PowerShell.Utility
+#requires -Modules Microsoft.PowerShell.Utility
 #requires -version 3
 <#
         File: PowerUpSQL.ps1
@@ -10288,7 +10288,7 @@ Function Invoke-SQLAuditPrivXpDirtree
                                 Write-Verbose -Message "$Instance : - Inveigh loaded."
 
                                 # Get IP of SQL Server instance
-                                $InstanceIP = Resolve-DnsName $ComputerName | Select-Object -Property IPaddress -ExpandProperty ipaddress
+                                $InstanceIP = [System.Net.Dns]::GetHostAddresses($ComputerName)
 
                                 # Start sniffing for hashes from that IP
                                 Write-Verbose -Message "$Instance : - Start sniffing..."
@@ -10623,7 +10623,7 @@ Function Invoke-SQLAuditPrivXpFileexist
                                 Write-Verbose -Message "$Instance : - Inveigh loaded."
 
                                 # Get IP of SQL Server instance
-                                $InstanceIP = Resolve-DnsName $ComputerName | Select-Object -Property IPaddress -ExpandProperty ipaddress
+                                $InstanceIP = [System.Net.Dns]::GetHostAddresses($ComputerName)
 
                                 # Start sniffing for hashes from that IP
                                 Write-Verbose -Message "$Instance : - Start sniffing..."


### PR DESCRIPTION
This pull request has minor changes to remove the DnsClient module requirement. Windows 7 doesn't support that module as it does not have the underlying WMI classes. 

See link below for list of Windows 8 modules not available for Windows 7.
http://blogs.msmvps.com/richardsiddaway/2012/12/14/powershell-v3-installed-modules/