### PR TITLE
Changes for PSv2 Compatibility

### DIFF
--- a/PowerUpSQL.ps1
+++ b/PowerUpSQL.ps1
@@ -1,4 +1,3 @@
-#requires -Modules Microsoft.PowerShell.Utility
 #requires -version 2
 <#
         File: PowerUpSQL.ps1
@@ -207,7 +206,7 @@ Function  Get-SQLConnectionTest
         [System.Management.Automation.Credential()]$Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Parameter(Mandatory = $false,
-                ValueFromPipeline,
+                ValueFromPipeline = $true,
                 ValueFromPipelineByPropertyName = $true,
         HelpMessage = 'SQL Server instance to connection to.')]
         [string]$Instance,
@@ -354,7 +353,7 @@ Function  Get-SQLConnectionTestThreaded
         [System.Management.Automation.Credential()]$Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Parameter(Mandatory = $false,
-                ValueFromPipeline,
+                ValueFromPipeline = $true,
                 ValueFromPipelineByPropertyName = $true,
         HelpMessage = 'SQL Server instance to connection to.')]
         [string]$Instance,
@@ -707,7 +706,7 @@ Function  Get-SQLQueryThreaded
         [System.Management.Automation.Credential()]$Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Parameter(Mandatory = $false,
-                ValueFromPipeline,
+                ValueFromPipeline = $true,
                 ValueFromPipelineByPropertyName = $true,
         HelpMessage = 'SQL Server instance to connection to.')]
         [string]$Instance,
@@ -977,7 +976,7 @@ Function  Invoke-SQLOSCmd
         [System.Management.Automation.Credential()]$Credential = [System.Management.Automation.PSCredential]::Empty,
 
         [Parameter(Mandatory = $false,
-                ValueFromPipeline,
+                ValueFromPipeline = $true,
                 ValueFromPipelineByPropertyName = $true,
         HelpMessage = 'SQL Server instance to connection to.')]
         [string]$Instance,
@@ -9026,7 +9025,7 @@ function Get-SQLInstanceScanUDP
     param(
 
         [Parameter(Mandatory = $true,
-                ValueFromPipeline,
+                ValueFromPipeline = $true,
                 ValueFromPipelineByPropertyName = $true,
         HelpMessage = 'Computer name or IP address to enumerate SQL Instance from.')]
         [string]$ComputerName,
@@ -9211,7 +9210,7 @@ function Get-SQLInstanceScanUDPThreaded
     param(
 
         [Parameter(Mandatory = $true,
-                ValueFromPipeline,
+                ValueFromPipeline = $true,
                 ValueFromPipelineByPropertyName = $true,
         HelpMessage = 'Computer name or IP address to enumerate SQL Instance from.')]
         [string]$ComputerName,

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ PowerUpSQL was designed with six objectives in mind:
 * Easy Server Exploitation: The Invoke-SQLEscalatePriv function attempts to obtain sysadmin privileges using identified vulnerabilities. 
 * Scalability: Multi-threading is supported on core functions so they can be executed against many SQL Servers quickly.
 * Flexibility: PowerUpSQL functions support the PowerShell pipeline so they can be used together, and with other scripts.
-* Portability: Default .net libraries are used and there are no dependencies on SQLPS or the SMO libraries. Functions have also been designed so they can be run independently. As a result, it's easy to use on any Windows system with PowerShell v3 installed.
+* Portability: Default .net libraries are used and there are no dependencies on SQLPS or the SMO libraries. Functions have also been designed so they can be run independently. As a result, it's easy to use on any Windows system with PowerShell v2 installed.
 
 
 ### Module Information


### PR DESCRIPTION
This addresses issue #4 to include support for PowerShell v2. 

- The #requires statement does not support the -Modules flag in PSv2
- The 'ValueFromPipeline' declaration needs to explicitly assign $true for PSv2

I also updated the README so that it mentions "... it's easy to use on any Windows system with PowerShell v2 installed".

Tested on:
- Windows 7 PowerShell v2.0
- Windows 7 PowerShell v5.0
- Windows 10 PowerShell v5.0

I was not able to run all functions and unable to test 8.1 at this time.