### PR TITLE
Powershell Bug splitting $_.properties.serviceprincipalname

### DIFF
--- a/PowerUpSQL.ps1
+++ b/PowerUpSQL.ps1
@@ -9135,7 +9135,7 @@ function Get-DomainSpn
             $SpnResults | ForEach-Object -Process {
                 [string]$SidBytes = [byte[]]"$($_.Properties.objectsid)".split(' ')
                 [string]$SidString = $SidBytes -replace ' ', ''
-                $Spn = $_.properties.serviceprincipalname.split(',')
+                $Spn = $_.properties.serviceprincipalname[0].split(',')
 
                 foreach ($item in $Spn)
                 {


### PR DESCRIPTION
Myself and several other pentesters I know have encountered an issue with Get-SQLInstanceDomain returning 0 instances on domain joined systems. I was able to track down the culprit this week through Cobalt Strike. Line 9138 assigns null to the $Spn variable. I originally removed the `.split(',')` as there were no commas in any of the `$_.properties.serviceprincipalname` values. That worked, but I talked to Will (@harmj0y) about the issue and he recommended specifying index 0 for `$_.properties.serviceprincipalname` due to quirkiness he has encountered in the past with AD objects in Powershell. This solved the issue and returned a list of SQL instances.