### PR TITLE
Invoke-SQLAgentJob as another method for command execution

### DIFF
--- a/PowerUpSQL.psd1
+++ b/PowerUpSQL.psd1
@@ -74,7 +74,8 @@
         'Invoke-SQLAuditPrivAutoExecSp',     
         'Invoke-SQLDumpInfo', 
         'Invoke-SQLEscalatePriv', 
-        'Invoke-SQLOSCmd'		
+        'Invoke-SQLOSCmd',
+        'Invoke-SQLAgentJob'	
     )
     FileList          = 'PowerUpSQL.psm1', 'PowerUpSQL.ps1', 'README.md'
 }


### PR DESCRIPTION
Start MSSQL Agent Jobs on servers where the SQL Agent service is running. These jobs can run operating system commands in the context of the service account, opening up an alternative to xp_cmdshell. 

The base SQL query and idea came from Nicholas Popovich (@pipefish_). The blog post can be found at https://www.optiv.com/blog/mssql-agent-jobs-for-command-execution.

I went with creating one common function to do this for us, if you think moving it one of the Audit functions I can refactor the code to fit. As always, let me know if my code sucks or if there are more optimal SQL queries.

Tested against:
* Microsoft SQL 2008
* Microsoft SQL 2012

*Does obviously require the SQL Agent service to be running, which is not default. Although, I have seen this in production environments.*

More infos:
https://technet.microsoft.com/en-us/library/ms189237(v=sql.105).aspx
https://msdn.microsoft.com/en-us/library/ms188283.aspx