### PR TITLE
Match local SQL services by name, not path

### DIFF
--- a/PowerUpSQL.ps1
+++ b/PowerUpSQL.ps1
@@ -14240,7 +14240,7 @@ Function  Get-SQLServiceLocal
         # Grab SQL Server services based on file path
         $SqlServices = Get-WmiObject -Class win32_service |
         Where-Object -FilterScript {
-            $_.pathname -like '*Microsoft SQL Server*'
+            $_.DisplayName -like 'SQL Server *'
         } |
         Select-Object -Property DisplayName, PathName, Name, StartName, State, SystemName, ProcessId
 


### PR DESCRIPTION
Not all SQL Server instances are in a path containing `Microsoft SQL Server`. When matching local SQL Server services, look for a `SQL Server` prefix in their names instead of this path.

I've seen such a setup in the wild during at least one penetration test.

Before:
```
PS C:\users\mattd\PowerUpSQL> Get-SQLServiceLocal | Format-Table

ComputerName Instance     ServiceDisplayName                                 ServiceName            ServicePath
------------ --------     ------------------                                 -----------            -----------
sql-2017-dev sql-2017-dev SQL Server Integration Services 14.0               MsDtsServer140         "C:\Program Files\Microsoft SQL Server\140\DTS\Binn\MsDtsSrvr.exe"
sql-2017-dev sql-2017-dev SQL Full-text Filter Daemon Launcher (MSSQLSERVER) MSSQLFDLauncher        "C:\Program Files\Microsoft SQL Server\MSSQL14.MSSQLSERVER\MSSQL\Binn\fdlauncher.exe" -s MSSQL14.MS...
sql-2017-dev sql-2017-dev SQL Server Launchpad (MSSQLSERVER)                 MSSQLLaunchpad         "C:\Program Files\Microsoft SQL Server\MSSQL14.MSSQLSERVER\MSSQL\Binn\launchpad.exe" -launcher RLau...
sql-2017-dev sql-2017-dev SQL Server Analysis Services (MSSQLSERVER)         MSSQLServerOLAPService "C:\Program Files\Microsoft SQL Server\MSAS14.MSSQLSERVER\OLAP\bin\msmdsrv.exe" -s "C:\Program File...
sql-2017-dev sql-2017-dev SQL Server Browser                                 SQLBrowser             "C:\Program Files (x86)\Microsoft SQL Server\90\Shared\sqlbrowser.exe"
sql-2017-dev sql-2017-dev SQL Server Agent (MSSQLSERVER)                     SQLSERVERAGENT         "C:\Program Files\Microsoft SQL Server\MSSQL14.MSSQLSERVER\MSSQL\Binn\SQLAGENT.EXE" -i MSSQLSERVER
sql-2017-dev sql-2017-dev SQL Server CEIP service (MSSQLSERVER)              SQLTELEMETRY           "C:\Program Files\Microsoft SQL Server\MSSQL14.MSSQLSERVER\MSSQL\Binn\sqlceip.exe" -Service
sql-2017-dev sql-2017-dev SQL Server VSS Writer                              SQLWriter              "C:\Program Files\Microsoft SQL Server\90\Shared\sqlwriter.exe"
sql-2017-dev sql-2017-dev SQL Server Analysis Services CEIP (MSSQLSERVER)    SSASTELEMETRY          "C:\Program Files\Microsoft SQL Server\MSAS14.MSSQLSERVER\OLAP\Bin\sqlceip.exe" -Service MSSQLSERVE...
sql-2017-dev sql-2017-dev SQL Server Integration Services CEIP service 14.0  SSISTELEMETRY140       "C:\Program Files\Microsoft SQL Server\140\DTS\Binn\sqlceip.exe" -Service default MSIS
sql-2017-dev sql-2017-dev Microsoft SQL Server IaaS Agent                    SQLIaaSExtension       "C:\Program Files\Microsoft SQL Server IaaS Agent\Bin\SqlIaaSExtension.Service.exe"
```

After:
```
PS C:\users\mattd\PowerUpSQL> Get-SQLServiceLocal | Format-Table

ComputerName Instance                 ServiceDisplayName                                ServiceName              ServicePath
------------ --------                 ------------------                                -----------              -----------
sql-2017-dev sql-2017-dev             SQL Server Integration Services 14.0              MsDtsServer140           "C:\Program Files\Microsoft SQL Server\140\DTS\Binn\MsDtsSrvr.exe"
sql-2017-dev sql-2017-dev             SQL Server Launchpad (MSSQLSERVER)                MSSQLLaunchpad           "C:\Program Files\Microsoft SQL Server\MSSQL14.MSSQLSERVER\MSSQL\Binn\launchpad.exe" -...
sql-2017-dev sql-2017-dev             SQL Server (MSSQLSERVER)                          MSSQLSERVER              "C:\Program Files\sqlserveraltdir\MSSQL14.MSSQLSERVER\MSSQL\Binn\sqlservr.exe" -sMSSQL...
sql-2017-dev sql-2017-dev             SQL Server Analysis Services (MSSQLSERVER)        MSSQLServerOLAPService   "C:\Program Files\Microsoft SQL Server\MSAS14.MSSQLSERVER\OLAP\bin\msmdsrv.exe" -s "C:...
sql-2017-dev sql-2017-dev             SQL Server Browser                                SQLBrowser               "C:\Program Files (x86)\Microsoft SQL Server\90\Shared\sqlbrowser.exe"
sql-2017-dev sql-2017-dev             SQL Server Agent (MSSQLSERVER)                    SQLSERVERAGENT           "C:\Program Files\Microsoft SQL Server\MSSQL14.MSSQLSERVER\MSSQL\Binn\SQLAGENT.EXE" -i...
sql-2017-dev sql-2017-dev             SQL Server CEIP service (MSSQLSERVER)             SQLTELEMETRY             "C:\Program Files\Microsoft SQL Server\MSSQL14.MSSQLSERVER\MSSQL\Binn\sqlceip.exe" -Se...
sql-2017-dev sql-2017-dev             SQL Server VSS Writer                             SQLWriter                "C:\Program Files\Microsoft SQL Server\90\Shared\sqlwriter.exe"
sql-2017-dev sql-2017-dev             SQL Server Analysis Services CEIP (MSSQLSERVER)   SSASTELEMETRY            "C:\Program Files\Microsoft SQL Server\MSAS14.MSSQLSERVER\OLAP\Bin\sqlceip.exe" -Servi...
sql-2017-dev sql-2017-dev             SQL Server Integration Services CEIP service 14.0 SSISTELEMETRY140         "C:\Program Files\Microsoft SQL Server\140\DTS\Binn\sqlceip.exe" -Service default MSIS
sql-2017-dev sql-2017-dev\ALTINSTANCE SQL Server (ALTINSTANCE)                          MSSQL$ALTINSTANCE        "C:\Program Files\AltSQLInstance\MSSQL14.ALTINSTANCE\MSSQL\Binn\sqlservr.exe" -sALTINS...
sql-2017-dev sql-2017-dev\ALTINSTANCE SQL Server Agent (ALTINSTANCE)                    SQLAgent$ALTINSTANCE     "C:\Program Files\AltSQLInstance\MSSQL14.ALTINSTANCE\MSSQL\Binn\SQLAGENT.EXE" -i ALTIN...
sql-2017-dev sql-2017-dev\ALTINSTANCE SQL Server CEIP service (ALTINSTANCE)             SQLTELEMETRY$ALTINSTANCE "C:\Program Files\AltSQLInstance\MSSQL14.ALTINSTANCE\MSSQL\Binn\sqlceip.exe" -Service ...
```

(The now non-matching `Microsoft SQL Server IaaS Agent` service is part of Azure's integration with SQL Server; I don't see how it would be useful to have here.)