### PR TITLE
Fix unapproved verbs on exported cmdlets

### DIFF
--- a/PowerUpSQL.ps1
+++ b/PowerUpSQL.ps1
@@ -14418,11 +14418,11 @@ Function  Get-SQLServiceLocal
 
 
 # -------------------------------------------
-# Function:  Create-SQLFilCLRDLL
+# Function:  New-SQLFilCLRDLL
 # -------------------------------------------
 # Author: Scott Sutherland
 # References: This was built of off work done by Lee Christensen (@tifkin_) and Nathan Kirk (@sekirkity).
-function Create-SQLFileCLRDll
+function New-SQLFileCLRDll
 {
     <#
             .SYNOPSIS
@@ -14642,9 +14642,9 @@ function Create-SQLFileCLRDll
 
 
 # -------------------------------------------
-# Function:  Create-SQLFileXpDll
+# Function:  New-SQLFileXpDll
 # -------------------------------------------
-function Create-SQLFileXpDll
+function New-SQLFileXpDll
 {
     <#
             .SYNOPSIS
@@ -14660,7 +14660,7 @@ function Create-SQLFileXpDll
             .PARAMETER OutFile
             Name of the Dll file to write to.
             .EXAMPLE
-            PS C:\temp> Create-SQLFileXpDll -OutFile c:\temp\test.dll -Command "echo test > c:\temp\test.txt" -ExportName xp_test
+            PS C:\temp> New-SQLFileXpDll -OutFile c:\temp\test.dll -Command "echo test > c:\temp\test.txt" -ExportName xp_test
 
             Creating DLL c:\temp\test.dll
             - Exported function name: xp_test
@@ -24066,7 +24066,7 @@ Blog on this script: http://clymb3r.wordpress.com/2013/11/03/powershell-and-toke
     }
 
 
-    function Create-ProcessWithToken
+    function New-ProcessWithToken
     {
         Param(
             [Parameter(Position=0, Mandatory=$true)]
@@ -24085,7 +24085,7 @@ Blog on this script: http://clymb3r.wordpress.com/2013/11/03/powershell-and-toke
             [Switch]
             $PassThru
         )
-        Write-Verbose "Entering Create-ProcessWithToken"
+        Write-Verbose "Entering New-ProcessWithToken"
         #Duplicate the token so it can be used to create a new process
         [IntPtr]$NewHToken = [IntPtr]::Zero
         $Success = $DuplicateTokenEx.Invoke($hToken, $Win32Constants.MAXIMUM_ALLOWED, [IntPtr]::Zero, 3, 1, [Ref]$NewHToken)
@@ -24387,7 +24387,7 @@ Blog on this script: http://clymb3r.wordpress.com/2013/11/03/powershell-and-toke
                     Set-DesktopACLs
                 }
 
-                Create-ProcessWithToken -hToken $hToken -ProcessName $CreateProcess -ProcessArgs $ProcessArgs -PassThru:$PassThru
+                New-ProcessWithToken -hToken $hToken -ProcessName $CreateProcess -ProcessArgs $ProcessArgs -PassThru:$PassThru
 
                 Invoke-RevertToSelf
             }

--- a/PowerUpSQL.psd1
+++ b/PowerUpSQL.psd1
@@ -8,8 +8,8 @@
     Description       = 'PowerUpSQL is an offensive toolkit designed for attacking SQL Server.  The PowerUpSQL module includes functions that support SQL Server discovery, auditing for common weak configurations, and privilege escalation on scale.  It is intended to be used during penetration tests and red team engagements. However, PowerUpSQL also includes many functions that could be used by administrators to inventory the SQL Servers on their ADS domain very quickly.  More information can be found at https://github.com/NetSPI/PowerUpSQL.'
     PowerShellVersion = '2.0'
     FunctionsToExport = @(  
-        'Create-SQLFileXpDll', 
-        'Create-SQLFileCLRDll', 
+        'New-SQLFileXpDll', 
+        'New-SQLFileCLRDll', 
         'Get-SQLAgentJob',
         'Get-SQLAssemblyFile',
         'Get-SQLAuditDatabaseSpec', 
@@ -116,4 +116,3 @@
     )
     FileList          = 'PowerUpSQL.psm1', 'PowerUpSQL.ps1', 'README.md'
 }
-

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For setup instructions, cheat sheets, blogs, function overviews, and usage infor
 ### Author, Contributors, and License
 * Author: Scott Sutherland (@_nullbind), NetSPI - 2018
 * Major Contributors: Antti Rantasaari, Eric Gruber (@egru), Thomas Elling (@thomaselling)
-* Contributors: Alexander Leary (@0xbadjuju), @leoloobeek, Andrew Luke(@Sw4mpf0x), Mike Manzotti (@mmanzo_), and @ktaranov
+* Contributors: Alexander Leary (@0xbadjuju), @leoloobeek, Andrew Luke(@Sw4mpf0x), Mike Manzotti (@mmanzo_), @ktaranov, and Ian Williams (@aph3rson)
 * License: BSD 3-Clause
 * Required Dependencies: None
 
@@ -37,4 +37,3 @@ For setup instructions, cheat sheets, blogs, function overviews, and usage infor
 
 I perform QA on functions before we publish them, but it's hard to consider every scenario. So I just wanted to say thanks to those of you that have taken the time to give me a heads up on issues with PowerUpSQL so that we can make it better. :)
 * Bug Reporters: @ClementNotin, @runvirus, @CaledoniaProject 
-

--- a/tests/PowerUpSQLTests.ps1
+++ b/tests/PowerUpSQLTests.ps1
@@ -26,7 +26,7 @@ Invoke-SQLOSCmdAgentJob
 Invoke-SQLOSCmdPython
 Invoke-SQLOSCmdR
 Invoke-SQLOSCmdOle
-Create-SQLFileCLRDll
+New-SQLFileCLRDll
 Get-SQLAssemblyFile
 #>
 
@@ -1313,7 +1313,7 @@ Invoke-SQLAuditSQLiSpSigned
 ######################################################
 
 <#
-Create-SQLFileXpDll 
+New-SQLFileXpDll 
 Get-SQLStoredProcedureSQLi
 Get-SQLServerLoginDefaultPw
 Get-SQLStoredProcedureAutoExec


### PR DESCRIPTION
Replaces the usage of `Create-` with `New-` in cmdlets, the approved equivalent.

Note that there are still two internal functions (`Enum-AllTokens` and `Free-AllTokens`) which use unapproved verbs - these don't give errors, on import, though.

Fixes #30.