### PR TITLE
Fixed Get-SQLServerLoginDefaultPw failure where multiple credentials are present

### DIFF
--- a/PowerUpSQL.ps1
+++ b/PowerUpSQL.ps1
@@ -15025,11 +15025,6 @@ Function  Get-SQLServerLoginDefaultPw
             return 
         }        
 
-        # Grab username and password
-        #Write-Verbose $TblResultsTemp
-		#$CurrentUsername = $TblResultsTemp.username
-        #$CurrentPassword = $TblResultsTemp.password
-
         # Test login
 		#Write-Verbose ($instance).ToString()
 		#Write-Verbose ($CurrentUsername).ToString()
@@ -15037,6 +15032,7 @@ Function  Get-SQLServerLoginDefaultPw
 		
 		# Grab and iterate username and password
 		for($i=0; $i -lt $TblResultsTemp.count; $i++){
+			#Write-Verbose $TblResultsTemp
 			$CurrentUsername = $TblResultsTemp.username[$i]
 			$CurrentPassword = $TblResultsTemp.password[$i]
 			$LoginTest = Get-SQLServerInfo -Instance $instance -Username $CurrentUsername -Password $CurrentPassword -SuppressVerbose

--- a/PowerUpSQL.ps1
+++ b/PowerUpSQL.ps1
@@ -15026,28 +15026,38 @@ Function  Get-SQLServerLoginDefaultPw
         }        
 
         # Grab username and password
-        $CurrentUsername = $TblResultsTemp.username
-        $CurrentPassword = $TblResultsTemp.password
+        #Write-Verbose $TblResultsTemp
+		#$CurrentUsername = $TblResultsTemp.username
+        #$CurrentPassword = $TblResultsTemp.password
 
         # Test login
-        $LoginTest = Get-SQLServerInfo -Instance $instance -Username $CurrentUsername -Password $CurrentPassword -SuppressVerbose
-        if($LoginTest){
+		#Write-Verbose ($instance).ToString()
+		#Write-Verbose ($CurrentUsername).ToString()
+		#Write-Verbose ($CurrentPassword).ToString()
+		
+		# Grab and iterate username and password
+		for($i=0; $i -lt $TblResultsTemp.count; $i++){
+			$CurrentUsername = $TblResultsTemp.username[$i]
+			$CurrentPassword = $TblResultsTemp.password[$i]
+			$LoginTest = Get-SQLServerInfo -Instance $instance -Username $CurrentUsername -Password $CurrentPassword -SuppressVerbose
+			if($LoginTest){
 
-            Write-Verbose "$Instance : Confirmed default credentials - $CurrentUsername/$CurrentPassword"
+				Write-Verbose "$Instance : Confirmed default credentials - $CurrentUsername/$CurrentPassword"
 
-            $SysadminStatus = $LoginTest | select IsSysadmin -ExpandProperty IsSysadmin
+				$SysadminStatus = $LoginTest | select IsSysadmin -ExpandProperty IsSysadmin
 
-            # Append if successful                      
-            $TblResults.Rows.Add(
-                $ComputerName,
-                $Instance,
-                $CurrentUsername,
-                $CurrentPassword,
-                $SysadminStatus
-            ) | Out-Null
-        }else{
-            Write-Verbose "$Instance : No credential matches were found."
-        }
+				# Append if successful                      
+				$TblResults.Rows.Add(
+					$ComputerName,
+					$Instance,
+					$CurrentUsername,
+					$CurrentPassword,
+					$SysadminStatus
+				) | Out-Null
+			}else{
+				Write-Verbose "$Instance : No credential matches were found."
+			}
+		}
     }
 
     End


### PR DESCRIPTION
On cases where there are multiple credentials (i.e. SQLEXPRESS) it will fail.
Fixed the issue by iteration.

Also mentioned in Issue#42
https://github.com/NetSPI/PowerUpSQL/issues/42