### PR TITLE
Resolved issue #67 and fixed error in Invoke-SQLUploadFileOle

### DIFF
--- a/PowerUpSQL.ps1
+++ b/PowerUpSQL.ps1
@@ -179,7 +179,7 @@ Function Get-SQLConnectionObject
             $AuthenticationType = "Current Windows Credentials"
 
             # Set connection string
-            $Connection.ConnectionString = "Server=$DacConn$Instance;Database=$Database;Integrated Security=SSPI;Connection Timeout=1$AppNameString$EncryptString$TrustCertString$WorkstationString"
+            $Connection.ConnectionString = "Server=$DacConn$Instance;Database=$Database;Integrated Security=SSPI;Connection Timeout=$TimeOut$AppNameString$EncryptString$TrustCertString$WorkstationString"
         }
         
         # Set authentcation type - provided windows user
@@ -17808,13 +17808,8 @@ Function  Invoke-SQLUploadFileOle
                 try
                 {
                     $FileBytes = [System.IO.File]::ReadAllBytes($InputFileFull)
-                    $FileDataTmp = New-Object System.Collections.Generic.List[System.Object]
-                    foreach ($b in $FileBytes)
-                    { 
-                        $FileDataTmp.Add($b.ToString("X2"))
-                    }
-
-                    $FileData = [system.String]::Join('', $FileDataTmp.ToArray())
+                    $FileDataTmp = [System.BitConverter]::ToString($FileBytes)
+                    $FileData = ($FileDataTmp -replace "\-", "")
                 }
                 catch
                 {


### PR DESCRIPTION
Hi!

I've resolved issue #67 that I'd reported earlier since that was a straightforward fix and also noticed that [my](https://github.com/NetSPI/PowerUpSQL/pull/55) `Invoke-SQLUploadFileOle` function can sometimes derail PowerShell interpreter when formatting big input file into hex interpretation.

To overcome that I've changed implementation to use different method for converting byte array into hexstring that works far more stable now.

Also, could we mention those two functions in PowerUpSQL's wiki, like for instance [here](https://github.com/NetSPI/PowerUpSQL/wiki/PowerUpSQL-Cheat-Sheet)? It would help anyone who's not aware they could use MSSQL to download/upload files :)

Hope you'll like it!

Cheers,
Mariusz.