### PR TITLE
Fixes for SysadminPrecheck. 

### DIFF
--- a/PowerUpSQL.ps1
+++ b/PowerUpSQL.ps1
@@ -22294,7 +22294,7 @@ Function Invoke-SQLAuditRoleDbOwner
                         {
                             # Check if user is already a sysadmin
                             $SysadminPreCheck = Get-SQLQuery -Instance $Instance -Username $Username -Password $Password -Credential $Credential -Query "SELECT IS_SRVROLEMEMBER('sysadmin','$CurrentLogin') as Status" -SuppressVerbose | Select-Object -Property Status -ExpandProperty Status
-                            if($SysadminPreCheck -eq 0)
+                            if($SysadminPreCheck -ne 1)
                             {
                                 # Status user
                                 Write-Verbose -Message "$Instance : - EXPLOITING: Verified that the current user ($CurrentLogin) is NOT a sysadmin."
@@ -22564,7 +22564,7 @@ Function Invoke-SQLAuditRoleDbDdlAdmin
                         {
                             # Check if user is already a sysadmin
                             $SysadminPreCheck = Get-SQLQuery -Instance $Instance -Username $Username -Password $Password -Credential $Credential -Query "SELECT IS_SRVROLEMEMBER('sysadmin','$CurrentLogin') as Status" -SuppressVerbose | Select-Object -Property Status -ExpandProperty Status
-                            if($SysadminPreCheck -eq 0)
+                            if($SysadminPreCheck -ne 1)
                             {
                                 # Status user
                                 Write-Verbose -Message "$Instance : - EXPLOITING: Verified that the current user ($CurrentLogin) is NOT a sysadmin."
@@ -22842,7 +22842,7 @@ Function Invoke-SQLAuditPrivImpersonateLogin
 
                         # Check if user is already a sysadmin
                         $SysadminPreCheck = Get-SQLQuery -Instance $Instance -Username $Username -Password $Password -Credential $Credential -Query "SELECT IS_SRVROLEMEMBER('sysadmin','$CurrentLogin') as Status" -SuppressVerbose | Select-Object -Property Status -ExpandProperty Status
-                        if($SysadminPreCheck -eq 0)
+                        if($SysadminPreCheck -ne 1)
                         {
                             # Status user
                             Write-Verbose -Message "$Instance : - EXPLOITING: Verified that the current user ($CurrentLogin) is NOT a sysadmin."
@@ -22880,7 +22880,7 @@ Function Invoke-SQLAuditPrivImpersonateLogin
 
                         # Check if user is already a sysadmin
                         $SysadminPreCheck = Get-SQLQuery -Instance $Instance -Username $Username -Password $Password -Credential $Credential -Query "SELECT IS_SRVROLEMEMBER('sysadmin','$CurrentLogin') as Status" -SuppressVerbose | Select-Object -Property Status -ExpandProperty Status
-                        if($SysadminPreCheck -eq 0)
+                        if($SysadminPreCheck -ne 1)
                         {
                             # Status user
                             Write-Verbose -Message "$Instance : - EXPLOITING: Verified that the current user ($CurrentLogin) is NOT a sysadmin."


### PR DESCRIPTION
Logis was -eq 0 even though it gives a null, so changed logic to -ne 1. Tested and works flawlessly.