### PR TITLE
Get-SQLServerInfo: Fixed variable name causing query failures in case-sensitive master databases

### DIFF
--- a/PowerUpSQL.ps1
+++ b/PowerUpSQL.ps1
@@ -3613,7 +3613,7 @@ Function  Get-SQLServerInfo
             END
 
             -- Get SQL Server Service Account
-            DECLARE @ServiceaccountName varchar(250)
+            DECLARE @ServiceAccountName varchar(250)
             EXECUTE master.dbo.xp_instance_regread
             N'HKEY_LOCAL_MACHINE', @SQLServerInstance,
             N'ObjectName',@ServiceAccountName OUTPUT, N'no_output'


### PR DESCRIPTION
This PR fixes issue related to [DAFT issue #3](https://github.com/NetSPI/DAFT/issues/3) where in some servers, `master` database might have case-sensitive collation set, rendering plenty of hardcoded SQL queries failing without meaningful context.

This PR addresses just a tiny example of such issues, where a simple case-sensitive oversight leads to a silent, clueless failure.

Regards,
Mariusz.