### PR TITLE
Add params (MaxDepth and StopOnSysAdmin) and perf increases to Get-SQLServerLinkCrawl

### DIFF
--- a/PowerUpSQL.ps1
+++ b/PowerUpSQL.ps1
@@ -15363,7 +15363,7 @@ Function Get-SQLServerLinkCrawl{
             } 
         }
 
-        $List = $List | Where-Object { $MaxDepth -eq 0 -or ($_.Path.Count - 1) -le $MaxDepth}
+        $List = $List | Where-Object { $MaxDepth -eq 0 -or ($_.Path.Count - 1) -le $MaxDepth }
 
         if($Export){
             $LinkList = New-Object System.Data.Datatable


### PR DESCRIPTION
This PR adds the following enhancements to `Get-SQLServerLinkCrawl`:
* Performance increase
   * Crawling will no longer re-visit traversed links (same server with the same user)
   * This avoids circular dependencies, and cut down runtimes from days to a single hour in test environments with tens of servers, hundreds of links, and many circular links
   * Cuts down on noise and query amounts significantly
* `MaxDepth` param
    * Allows for a max depth of the crawl, which can help to early exit in large environments
* `StopOnSysAdmin` param
    * Stop crawl upon finding the first SysAdmin link 