### PR TITLE
Update PowerUpSQL.ps1

### DIFF
--- a/PowerUpSQL.ps1
+++ b/PowerUpSQL.ps1
@@ -15163,7 +15163,11 @@ Function  Get-SQLServerLoginDefaultPw
         }else{
             Write-Verbose "$Instance : No instance match found."
             return 
-        }        
+        }
+
+ 	if($TblResultsTemp.GetType().Name  -eq  "DataRow"){
+        	$TblResultsTemp = ,$TblResultsTemp
+	} 
 
         # Test login
 		#Write-Verbose ($instance).ToString()


### PR DESCRIPTION
Because when there is only one credential, it can lead to errors and make it difficult to determine if weak passwords exist.