### PR TITLE
Return full SPN data when CheckMgmt is used

### DIFF
--- a/PowerUpSQL.ps1
+++ b/PowerUpSQL.ps1
@@ -16392,10 +16392,8 @@ Function  Get-SQLInstanceDomain
         {
             Write-Verbose -Message 'Parsing SQL Server instances from the UDP scan...'
             $Tbl1 = $TblMgmtSQLServers |
-            Select-Object -Property ComputerName, Instance |
             Sort-Object -Property ComputerName, Instance
             $Tbl2 = $TblSQLServerSpns |
-            Select-Object -Property ComputerName, Instance |
             Sort-Object -Property ComputerName, Instance
             $Tbl3 = $Tbl1 + $Tbl2
 


### PR DESCRIPTION
Removes the `Select-Object` commands from the `Get-SQLInstanceDomain -CheckMgmt` results.

These cause all other properties to be removed, losing valuable info such as `SPN` and `DomainAccount`.

NOTE: I have not tested this in an environment that actually has `MSServerClusterMgmtAPI` SPNs configured. I wouldn't anticipate this causing any issues, but could potentially use some testing.